### PR TITLE
Enhancements for full anonymisation with staging data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     implementation "org.springframework.boot:spring-boot-starter-batch"
+    implementation "org.springframework.boot:spring-boot-starter-validation"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
@@ -152,7 +152,7 @@ public class BatchConfig {
       CandidateEntityRepository candidateEntityRepository) {
     return new RepositoryItemWriterBuilder<CandidateEntity>()
         .repository(candidateEntityRepository)
-        .methodName("save")
+        .methodName("saveAndFlush")
         .build();
   }
 

--- a/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
@@ -10,10 +10,12 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.batch.item.validator.ValidationException;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.tctalent.anonymization.batch.listener.LoggingDocumentWriteListener;
 import org.tctalent.anonymization.batch.listener.LoggingJobExecutionListener;
@@ -22,6 +24,7 @@ import org.tctalent.anonymization.batch.listener.LoggingRestToDocumentProcessLis
 import org.tctalent.anonymization.batch.listener.LoggingRestToEntityProcessListener;
 import org.tctalent.anonymization.batch.listener.LoggingRestReadListener;
 import org.tctalent.anonymization.batch.listener.LoggingEntityWriteListener;
+import org.tctalent.anonymization.batch.listener.LoggingSkipListener;
 import org.tctalent.anonymization.domain.entity.CandidateEntity;
 import org.tctalent.anonymization.domain.document.CandidateDocument;
 import org.tctalent.anonymization.model.IdentifiableCandidate;
@@ -97,7 +100,8 @@ public class BatchConfig {
       LoggingChunkListener loggingChunkListener,
       LoggingRestReadListener loggingRestReadListener,
       LoggingRestToEntityProcessListener loggingRestToEntityProcessListener,
-      LoggingEntityWriteListener loggingEntityWriteListener) {
+      LoggingEntityWriteListener loggingEntityWriteListener,
+      LoggingSkipListener loggingSkipListener) {
 
     return new StepBuilder("candidateRestToAuroraStep", jobRepository)
         .<IdentifiableCandidate, CandidateEntity>chunk(batchProperties.getChunkSize(), transactionManager)
@@ -109,6 +113,9 @@ public class BatchConfig {
         .listener(loggingRestToEntityProcessListener)
         .listener(loggingEntityWriteListener)
         .faultTolerant()
+        .skip(DataIntegrityViolationException.class)
+        .skip(ValidationException.class)
+        .listener(loggingSkipListener)
         .skipPolicy(new ConditionalSkipPolicy(batchProperties.getMaxReadSkips()))
         .build();
   }

--- a/src/main/java/org/tctalent/anonymization/batch/listener/LoggingChunkListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/listener/LoggingChunkListener.java
@@ -31,7 +31,7 @@ public class LoggingChunkListener implements ChunkListener {
     Throwable exception = stepExecution.getFailureExceptions().isEmpty() ? null : stepExecution.getFailureExceptions().get(0);
 
     LogBuilder.builder(log)
-        .action("Error processing chunk")
+        .action("Error while processing chunk")
         .message("Chunk details: " + stepExecution + " | Error: " + (exception != null ? exception.getMessage() : "Unknown error"))
         .logError(exception);
   }

--- a/src/main/java/org/tctalent/anonymization/batch/listener/LoggingChunkListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/listener/LoggingChunkListener.java
@@ -21,7 +21,7 @@ public class LoggingChunkListener implements ChunkListener {
   public void afterChunk(ChunkContext context) {
     LogBuilder.builder(log)
         .action("Chunk processed successfully")
-        .message("Chunk details:" + context.getStepContext().getStepExecution())
+        .message("Chunk details: " + context.getStepContext().getStepExecution())
         .logInfo();
   }
 

--- a/src/main/java/org/tctalent/anonymization/batch/listener/LoggingRestToEntityProcessListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/listener/LoggingRestToEntityProcessListener.java
@@ -21,7 +21,7 @@ public class LoggingRestToEntityProcessListener implements ItemProcessListener<I
   public void onProcessError(IdentifiableCandidate item, Exception e) {
     LogBuilder.builder(log)
         .action("Error processing item")
-        .message("Item details:" + item.toString())
+        .message("Item details: " + item.toString())
         .logError(e);
   }
 }

--- a/src/main/java/org/tctalent/anonymization/batch/listener/LoggingSkipListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/listener/LoggingSkipListener.java
@@ -2,10 +2,9 @@ package org.tctalent.anonymization.batch.listener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.SkipListener;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.tctalent.anonymization.domain.entity.BatchFailedItemEntity;
 import org.tctalent.anonymization.domain.entity.CandidateEntity;
@@ -16,27 +15,19 @@ import org.tctalent.anonymization.service.BatchFailedItemService;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LoggingSkipListener implements SkipListener<IdentifiableCandidate, CandidateEntity>,
-    StepExecutionListener {
+@StepScope
+public class LoggingSkipListener implements SkipListener<IdentifiableCandidate, CandidateEntity> {
 
   private final BatchFailedItemService batchFailedItemService;
 
+  @Value("#{stepExecution.jobExecution.id}")
   private Long jobExecutionId;
+
+  @Value("#{stepExecution.id}")
   private Long stepExecutionId;
+
+  @Value("#{stepExecution.stepName}")
   private String stepName;
-
-  // Capture StepExecution info to use in onSkip callbacks
-  @Override
-  public void beforeStep(StepExecution stepExecution) {
-    this.jobExecutionId = stepExecution.getJobExecution().getId();
-    this.stepExecutionId = stepExecution.getId();
-    this.stepName = stepExecution.getStepName();
-  }
-
-  @Override
-  public ExitStatus afterStep(StepExecution stepExecution) {
-    return stepExecution.getExitStatus();
-  }
 
   @Override
   public void onSkipInProcess(IdentifiableCandidate item, Throwable t) {

--- a/src/main/java/org/tctalent/anonymization/batch/listener/LoggingSkipListener.java
+++ b/src/main/java/org/tctalent/anonymization/batch/listener/LoggingSkipListener.java
@@ -1,0 +1,80 @@
+package org.tctalent.anonymization.batch.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+import org.tctalent.anonymization.domain.entity.BatchFailedItemEntity;
+import org.tctalent.anonymization.domain.entity.CandidateEntity;
+import org.tctalent.anonymization.model.IdentifiableCandidate;
+import org.tctalent.anonymization.service.BatchFailedItemService;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoggingSkipListener implements SkipListener<IdentifiableCandidate, CandidateEntity>,
+    StepExecutionListener {
+
+  private final BatchFailedItemService batchFailedItemService;
+
+  private Long jobExecutionId;
+  private Long stepExecutionId;
+  private String stepName;
+
+  // Capture StepExecution info to use in onSkip callbacks
+  @Override
+  public void beforeStep(StepExecution stepExecution) {
+    this.jobExecutionId = stepExecution.getJobExecution().getId();
+    this.stepExecutionId = stepExecution.getId();
+    this.stepName = stepExecution.getStepName();
+  }
+
+  @Override
+  public ExitStatus afterStep(StepExecution stepExecution) {
+    return stepExecution.getExitStatus();
+  }
+
+  @Override
+  public void onSkipInProcess(IdentifiableCandidate item, Throwable t) {
+    String publicId = item.getPublicId();
+    // todo log builder
+    log.warn("Skipping item in PROCESSING due to error: {}, item: {}", t.getMessage(), publicId);
+
+    BatchFailedItemEntity failedItem = BatchFailedItemEntity.builder()
+        .jobExecutionId(jobExecutionId)
+        .stepExecutionId(stepExecutionId)
+        .stepName(stepName)
+        .itemType("IdentifiableCandidate")
+        .itemPublicId(publicId)
+        .errorPhase("PROCESSING")
+        .errorMessage(t.getMessage())
+        .build();
+
+    batchFailedItemService.recordFailure(failedItem);
+  }
+
+  @Override
+  public void onSkipInWrite(CandidateEntity item, Throwable t) {
+    String publicId = item.getPublicId();
+    // todo log builder
+    log.warn("Skipping item in WRITING due to error: {}, item: {}", t.getMessage(), publicId);
+
+    BatchFailedItemEntity failedItem = BatchFailedItemEntity.builder()
+        .jobExecutionId(jobExecutionId)
+        .stepExecutionId(stepExecutionId)
+        .stepName(stepName)
+        .itemType("CandidateEntity")
+        .itemPublicId(publicId)
+        .errorPhase("WRITING")
+        .errorMessage(t.getMessage())
+        .build();
+
+    batchFailedItemService.recordFailure(failedItem);
+  }
+
+
+}

--- a/src/main/java/org/tctalent/anonymization/batch/processor/ModelToEntityItemProcessor.java
+++ b/src/main/java/org/tctalent/anonymization/batch/processor/ModelToEntityItemProcessor.java
@@ -1,8 +1,14 @@
 package org.tctalent.anonymization.batch.processor;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
+import jakarta.validation.Validator;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.validator.ValidationException;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.tctalent.anonymization.domain.entity.CandidateEntity;
@@ -26,10 +32,31 @@ public class ModelToEntityItemProcessor implements
     ItemProcessor<IdentifiableCandidate, CandidateEntity> {
 
   private final AnonymizationService anonymizationService;
+  private final Validator validator;
 
+  @Valid
   @Override
   public CandidateEntity process(@NonNull final IdentifiableCandidate model) {
-    return anonymizationService.anonymizeToEntity(model);
+    CandidateEntity entity = anonymizationService.anonymizeToEntity(model);
+
+    // Perform validation - we do it this way so validation happens before hibernate attempts to
+    // commit the processed entity. Validation failures during Hibernate commits cause the entire
+    // batch chunk to fail, whereas this way a single item failure is skipped, logged, and
+    // batch processing continues from the next item
+    Set<ConstraintViolation<CandidateEntity>> violations = validator.validate(entity);
+    if (!violations.isEmpty()) {
+      String message = violations.stream()
+          .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+          .collect(Collectors.joining("; "));
+
+      // todo - sm - use log builder
+      log.warn("Validation failed for CandidateEntity: {}", message);
+
+      // Throw an exception so Spring Batch can skip the item and continue processing the next item
+      throw new ValidationException("CandidateEntity validation failed: " + message);
+    }
+
+    return entity;
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/domain/entity/BatchFailedItemEntity.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/BatchFailedItemEntity.java
@@ -1,0 +1,39 @@
+package org.tctalent.anonymization.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "batch_failed_items")
+@SequenceGenerator(name = "seq_gen", sequenceName = "candidate_certification_id_seq", allocationSize = 1)
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchFailedItemEntity extends AbstractDomainEntity<Long>{
+
+  @Column(name = "step_execution_id", nullable = false)
+  private Long stepExecutionId;
+
+  @Column(name = "step_name", length = 100)
+  private String stepName;
+
+  @Column(name = "item_type", length = 50)
+  private String itemType;
+
+  @Column(name = "item_public_id", length = 100)
+  private String itemPublicId;
+
+  @Column(name = "error_phase", length = 20)
+  private String errorPhase;
+
+  @Column(name = "error_message")
+  private String errorMessage;
+
+}

--- a/src/main/java/org/tctalent/anonymization/domain/entity/BatchFailedItemEntity.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/BatchFailedItemEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,11 +13,15 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
+@Builder
 @Table(name = "batch_failed_items")
 @SequenceGenerator(name = "seq_gen", sequenceName = "candidate_certification_id_seq", allocationSize = 1)
 @NoArgsConstructor
 @AllArgsConstructor
 public class BatchFailedItemEntity extends AbstractDomainEntity<Long>{
+
+  @Column(name = "job_execution_id", nullable = false)
+  private Long jobExecutionId;
 
   @Column(name = "step_execution_id", nullable = false)
   private Long stepExecutionId;

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateDestination.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateDestination.java
@@ -25,12 +25,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.tctalent.anonymization.domain.common.YesNoUnsure;
 
-// todo - sm - check this - it's called Destination in the API schema
 @Getter
 @Setter
 @Entity
@@ -45,7 +45,8 @@ public class CandidateDestination extends AbstractDomainEntity<Long>
     private CandidateEntity candidate;
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = false)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = false, length = 3)
     private String countryIsoCode;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateEducation.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateEducation.java
@@ -25,6 +25,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,7 +49,8 @@ public class CandidateEducation extends AbstractDomainEntity<Long> {
     private EducationType educationType;
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = true)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = true, length = 3)
     private String countryIsoCode;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateEntity.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateEntity.java
@@ -2,6 +2,7 @@ package org.tctalent.anonymization.domain.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -58,6 +59,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
 
   private YesNo availImmediate;
 
+  @Size(max = 255)
+  @Column(name = "avail_immediate_job_ops", length = 255)
   private String availImmediateJobOps;
 
   @Enumerated(EnumType.STRING)
@@ -66,7 +69,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private String availImmediateNotes;
 
   // Store the isoCode directly instead of a foreign key reference
-  @Column(name = "birth_country_iso_code", nullable = true)
+  @Size(max = 3)
+  @Column(name = "birth_country_iso_code", nullable = true, length = 3)
   private String birthCountryIsoCode;
 
   /**
@@ -74,6 +78,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
    * CascadeType.ALL cascades all operations (persist, merge, remove, etc.) to certifications.
    * orphanRemoval=true ensures that certifications removed from this list are deleted.
    */
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderBy("dateCompleted DESC")
   private List<CandidateCertification> candidateCertifications = new ArrayList<>();
@@ -91,6 +96,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateCertifications.addAll(certifications);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateCitizenship> candidateCitizenships = new ArrayList<>();
 
@@ -100,6 +106,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateCitizenships.addAll(citizenships);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateDependant> candidateDependants = new ArrayList<>();
 
@@ -109,6 +116,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateDependants.addAll(dependants);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateDestination> candidateDestinations = new ArrayList<>();
 
@@ -118,6 +126,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateDestinations.addAll(destinations);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderBy("yearCompleted DESC")
   private List<CandidateEducation> candidateEducations = new ArrayList<>();
@@ -128,6 +137,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateEducations.addAll(educations);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<@Valid CandidateExam> candidateExams = new ArrayList<>();
 
@@ -137,6 +147,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateExams.addAll(exams);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateLanguage> candidateLanguages = new ArrayList<>();
 
@@ -148,6 +159,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
 
   private String candidateMessage;
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateOccupation> candidateOccupations = new ArrayList<>();
 
@@ -157,6 +169,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateOccupations.addAll(occupations);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateSkill> candidateSkills = new ArrayList<>();
 
@@ -166,6 +179,7 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
     this.candidateSkills.addAll(skills);
   }
 
+  @Valid
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CandidateVisaCheck> candidateVisaChecks = new ArrayList<>();
 
@@ -178,6 +192,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   @Enumerated(EnumType.STRING)
   private YesNo canDrive;
 
+  @Size(max = 255)
+  @Column(name = "city", length = 255)
   private String city;
 
   @Enumerated(EnumType.STRING)
@@ -185,12 +201,13 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
 
   private String conflictNotes;
 
-  private Boolean contactConsentTcPartners;
-
   private Boolean contactConsentRegistration;
 
+  private Boolean contactConsentTcPartners;
+
   // Store the isoCode directly instead of a foreign key reference
-  @Column(name = "country_iso_code", nullable = false)
+  @Size(max = 3)
+  @Column(name = "country_iso_code", nullable = false, length = 3)
   private String countryIsoCode;
 
   @Enumerated(EnumType.STRING)
@@ -198,6 +215,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
 
   private LocalDate covidVaccinatedDate;
 
+  @Size(max = 255)
+  @Column(name = "covid_vaccine_name", length = 255)
   private String covidVaccineName;
 
   private String covidVaccineNotes;
@@ -219,13 +238,16 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private DocumentStatus drivingLicense;
 
   // Store the isoCode directly instead of a foreign key reference
-  @Column(name = "driving_license_country_iso_code", nullable = true)
+  @Size(max = 3)
+  @Column(name = "driving_license_country_iso_code", nullable = true, length = 3)
   private String drivingLicenseCountryIsoCode;
 
   private LocalDate drivingLicenseExp;
 
   private String englishAssessment;
 
+  @Size(max = 255)
+  @Column(name = "english_assessment_score_ielts", length = 255)
   private String englishAssessmentScoreIelts;
 
   @Enumerated(EnumType.STRING)
@@ -264,8 +286,12 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private BigDecimal ieltsScore;
 
   @Convert(converter = IntRecruitReasonConverter.class)
+  @Size(max = 255)
+  @Column(name = "int_recruit_reasons", length = 255)
   private List<IntRecruitReason> intRecruitReasons;
 
+  @Size(max = 255)
+  @Column(name = "int_recruit_other", length = 255)
   private String intRecruitOther;
 
   @Enumerated(EnumType.STRING)
@@ -276,6 +302,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private String leftHomeNotes;
 
   @Convert(converter = LeftHomeReasonsConverter.class)
+  @Size(max = 255)
+  @Column(name = "left_home_reasons", length = 255)
   private List<LeftHomeReason> leftHomeReasons;
 
   @Enumerated(EnumType.STRING)
@@ -287,6 +315,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   @Column(name = "max_education_level", nullable = true)
   private Integer maxEducationLevel;
 
+  @Size(max = 255)
+  @Column(name = "media_willingness", length = 255)
   private String mediaWillingness;
 
   @Enumerated(EnumType.STRING)
@@ -308,7 +338,8 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private YesNo monitoringEvaluationConsent;
 
   // Store the isoCode directly instead of a foreign key reference
-  @Column(name = "nationality_iso_code", nullable = false)
+  @Size(max = 3)
+  @Column(name = "nationality_iso_code", nullable = false, length = 3)
   private String nationalityIsoCode;
 
   private Long numberDependants;
@@ -316,8 +347,12 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   @Enumerated(EnumType.STRING)
   private YesNoUnsure partnerRegistered;
 
+  @Size(max = 255)
+  @Column(name = "partner_public_id", length = 255)
   private String partnerPublicId;
 
+  @Size(max = 255)
+  @Column(name = "partner_citizenship", length = 255)
   private String partnerCitizenship;
 
   /**
@@ -354,17 +389,21 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   private YesNo partnerEnglish;
 
   // Store the written_level directly instead of a foreign key reference
-  @Column(name = "partner_english_level", nullable = true)
+  @Size(max = 255)
+  @Column(name = "partner_english_level", nullable = true, length = 255)
   private String partnerEnglishLevel;
 
   @Enumerated(EnumType.STRING)
   private IeltsStatus partnerIelts;
 
+  @Size(max = 255)
+  @Column(name = "partner_ielts_score", length = 255)
   private String partnerIeltsScore;
 
   private Long partnerIeltsYr;
 
   // Store the isco08Code directly instead of a foreign key reference
+  @Size(max = 255)
   @Column(name = "partner_occupation_isco08_code", nullable = true)
   private String partnerOccupationIsco08Code;
 
@@ -380,8 +419,12 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   @Enumerated(EnumType.STRING)
   private YesNoUnsure returnedHome;
 
+  @Size(max = 255)
+  @Column(name = "returned_home_reason", length = 255)
   private String returnedHomeReason;
 
+  @Size(max = 255)
+  @Column(name = "returned_home_reason_no", length = 255)
   private String returnedHomeReasonNo;
 
   @Enumerated(EnumType.STRING)
@@ -393,15 +436,20 @@ public class CandidateEntity extends AbstractDomainEntity<Long> {
   @Enumerated(EnumType.STRING)
   private YesNo resettleThird;
 
+  @Size(max = 255)
+  @Column(name = "resettle_third_status", length = 255)
   private String resettleThirdStatus;
 
+  @Size(max = 255)
+  @Column(name = "state", length = 255)
   private String state;
 
   @Enumerated(EnumType.STRING)
   private CandidateStatus status;
 
   // Store the survey type name directly instead of a foreign key reference
-  @Column(name = "survey_type", nullable = true)
+  @Size(max = 255)
+  @Column(name = "survey_type", nullable = true, length = 255)
   private String surveyType;
 
   private String surveyComment;

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateJobExperience.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateJobExperience.java
@@ -23,6 +23,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,9 +43,11 @@ public class CandidateJobExperience extends AbstractDomainEntity<Long> {
     private CandidateEntity candidate;
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = false)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = false, length = 3)
     private String countryIsoCode;
 
+    @Valid
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "candidate_occupation_id")
     private CandidateOccupation candidateOccupation;

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateOccupation.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateOccupation.java
@@ -25,6 +25,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -44,6 +46,7 @@ public class CandidateOccupation extends AbstractDomainEntity<Long> {
     private CandidateEntity candidate;
 
     // Store the isco08Code directly instead of a foreign key reference
+    @Size(max = 255)
     @Column(name = "isco08_code", nullable = true)
     private String isco08Code;
 
@@ -53,6 +56,7 @@ public class CandidateOccupation extends AbstractDomainEntity<Long> {
 
     private Long yearsExperience;
 
+    @Valid
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidateOccupation", cascade = CascadeType.ALL)
     private List<CandidateJobExperience> candidateJobExperiences = new ArrayList<>();
 

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateVisaCheck.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateVisaCheck.java
@@ -27,6 +27,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
@@ -49,7 +51,8 @@ public class CandidateVisaCheck extends AbstractDomainEntity<Long> {
     private CandidateEntity candidate;
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = false)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = false, length = 3)
     private String countryIsoCode;
 
     @Enumerated(EnumType.STRING)
@@ -79,6 +82,7 @@ public class CandidateVisaCheck extends AbstractDomainEntity<Long> {
     @Enumerated(EnumType.STRING)
     private FamilyRelations destinationFamily;
 
+    @Valid
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidateVisaCheck", cascade = CascadeType.ALL)
     private Set<CandidateVisaJobCheck> candidateVisaJobChecks = new HashSet<>();
 

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateVisaJobCheck.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateVisaJobCheck.java
@@ -27,6 +27,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -50,6 +52,7 @@ public class CandidateVisaJobCheck extends AbstractDomainEntity<Long> {
     /**
      * Associated job opportunity
      */
+    @Valid
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "job_opp_id")
     SalesforceJobOpp jobOpp;
@@ -61,6 +64,7 @@ public class CandidateVisaJobCheck extends AbstractDomainEntity<Long> {
     private YesNo qualification;
 
     // Store the isco08Code directly instead of a foreign key reference
+    @Size(max = 255)
     @Column(name = "isco08_code", nullable = true)
     private String isco08Code;
 

--- a/src/main/java/org/tctalent/anonymization/domain/entity/Employer.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/Employer.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.Nullable;
@@ -32,7 +33,8 @@ import org.springframework.lang.Nullable;
 public class Employer extends AbstractDomainEntity<Long> {
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = false)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = false, length = 3)
     private String countryIsoCode;
 
     /**

--- a/src/main/java/org/tctalent/anonymization/domain/entity/SalesforceJobOpp.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/SalesforceJobOpp.java
@@ -26,6 +26,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import lombok.Getter;
@@ -41,9 +43,11 @@ import org.tctalent.anonymization.domain.common.JobOpportunityStage;
 public class SalesforceJobOpp extends AbstractDomainEntity<Long> {
 
     // Store the isoCode directly instead of a foreign key reference
-    @Column(name = "country_iso_code", nullable = false)
+    @Size(max = 3)
+    @Column(name = "country_iso_code", nullable = false, length = 3)
     private String countryIsoCode;
 
+    @Valid
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "employer_id")
     private Employer employerEntity;

--- a/src/main/java/org/tctalent/anonymization/repository/BatchFailedItemEntityRepository.java
+++ b/src/main/java/org/tctalent/anonymization/repository/BatchFailedItemEntityRepository.java
@@ -1,0 +1,7 @@
+package org.tctalent.anonymization.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tctalent.anonymization.domain.entity.BatchFailedItemEntity;
+
+public interface BatchFailedItemEntityRepository extends JpaRepository<BatchFailedItemEntity, Long> {
+}

--- a/src/main/java/org/tctalent/anonymization/service/BatchFailedItemService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchFailedItemService.java
@@ -1,0 +1,17 @@
+package org.tctalent.anonymization.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.tctalent.anonymization.domain.entity.BatchFailedItemEntity;
+import org.tctalent.anonymization.repository.BatchFailedItemEntityRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BatchFailedItemService {
+
+  private final BatchFailedItemEntityRepository batchFailedItemRepository;
+
+  public void recordFailure(BatchFailedItemEntity failedItem) {
+    batchFailedItemRepository.save(failedItem);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,14 +2,14 @@ server:
   port: ${SERVER_PORT:8082}
 
 batch:
-  chunk-size: ${BATCH_CHUNK_SIZE:100}
-  page-size: ${BATCH_PAGE_SIZE:100}
+  chunk-size: ${BATCH_CHUNK_SIZE:20}
+  page-size: ${BATCH_PAGE_SIZE:20}
   max-read-skips: ${BATCH_MAX_READ_SKIPS:10}
   fetch-delay-millis: ${BATCH_FETCH_DELAY_MILLIS:1000}
 
 tc-service:
   apiUrl: ${TC_API_URL:http://localhost:8080/api/admin}
-  search-id: ${TC_SEARCH_ID:4672}
+  search-id: ${TC_SEARCH_ID:2679}
   username: ${TC_USERNAME:appAnonDatabaseService}
   password: ${TC_PASSWORD:12345678} # todo - sm - just a dummy value for local testing
 
@@ -58,4 +58,4 @@ spring:
     jdbc:
       initialize-schema: never # batch schema are initialised by flyway
     job:
-      enabled: false # enable/disable auto-run of jobs
+      enabled: true # enable/disable auto-run of jobs

--- a/src/main/resources/db/migration/V1_30__alter_column_type_from_varying_character_to_text.sql
+++ b/src/main/resources/db/migration/V1_30__alter_column_type_from_varying_character_to_text.sql
@@ -1,0 +1,99 @@
+-- alter description column type to text
+ALTER TABLE candidate
+    ALTER COLUMN arrest_imprison_notes TYPE text,
+    ALTER COLUMN avail_immediate_notes TYPE text,
+    ALTER COLUMN candidate_message TYPE text,
+    ALTER COLUMN conflict_notes TYPE text,
+    ALTER COLUMN covid_vaccine_notes TYPE text,
+    ALTER COLUMN crime_convict_notes TYPE text,
+    ALTER COLUMN dest_limit_notes TYPE text,
+    ALTER COLUMN english_assessment TYPE text,
+    ALTER COLUMN family_move_notes TYPE text,
+    ALTER COLUMN french_assessment TYPE text,
+    ALTER COLUMN health_issues_notes TYPE text,
+    ALTER COLUMN home_location TYPE text,
+    ALTER COLUMN host_challenges TYPE text,
+    ALTER COLUMN host_entry_legally_notes TYPE text,
+    ALTER COLUMN host_entry_year_notes TYPE text,
+    ALTER COLUMN int_recruit_rural_notes TYPE text,
+    ALTER COLUMN left_home_notes TYPE text,
+    ALTER COLUMN marital_status_notes TYPE text,
+    ALTER COLUMN military_notes TYPE text,
+    ALTER COLUMN residence_status_notes TYPE text,
+    ALTER COLUMN survey_comment TYPE text,
+    ALTER COLUMN unhcr_notes TYPE text,
+    ALTER COLUMN unrwa_notes TYPE text,
+    ALTER COLUMN visa_issues_notes TYPE text,
+    ALTER COLUMN visa_reject_notes TYPE text,
+    ALTER COLUMN work_abroad_notes TYPE text,
+    ALTER COLUMN work_permit_desired_notes TYPE text,
+    ALTER COLUMN partner_occupation_name TYPE text;
+
+ALTER TABLE candidate_certification
+    ALTER COLUMN name TYPE text,
+    ALTER COLUMN institution TYPE text;
+
+ALTER TABLE candidate_citizenship
+    ALTER COLUMN notes TYPE text;
+
+ALTER TABLE candidate_dependant
+    ALTER COLUMN relation_other TYPE text;
+
+ALTER TABLE candidate_destination
+    ALTER COLUMN notes TYPE text;
+
+ALTER TABLE candidate_education
+    ALTER COLUMN institution TYPE text,
+    ALTER COLUMN course_name TYPE text;
+
+ALTER TABLE candidate_exam
+    ALTER COLUMN other_exam TYPE text,
+    ALTER COLUMN score TYPE text,
+    ALTER COLUMN notes TYPE text;
+
+ALTER TABLE candidate_job_experience
+    ALTER COLUMN company_name TYPE text,
+    ALTER COLUMN role TYPE text,
+    ALTER COLUMN description TYPE text;
+
+ALTER TABLE candidate_language
+    ALTER COLUMN name TYPE text,
+    ALTER COLUMN written_level TYPE text,
+    ALTER COLUMN spoken_level TYPE text,
+    ALTER COLUMN migration_language TYPE text;
+
+ALTER TABLE candidate_occupation
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE candidate_skill
+    ALTER COLUMN skill TYPE text,
+    ALTER COLUMN time_period TYPE text;
+
+ALTER TABLE candidate_visa_job_check
+    ALTER COLUMN name TYPE text,
+    ALTER COLUMN age_requirement TYPE text;
+
+ALTER TABLE country
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE education_major
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE language
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE language_level
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE occupation
+    ALTER COLUMN name TYPE text;
+
+ALTER TABLE salesforce_job_opp
+    ALTER COLUMN employer_hired_internationally TYPE text;
+
+ALTER TABLE survey_type
+    ALTER COLUMN name TYPE text;
+
+
+
+

--- a/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
+++ b/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
@@ -1,0 +1,13 @@
+-- V2__create_batch_failed_items_table.sql
+
+CREATE TABLE batch_failed_items (
+    id SERIAL PRIMARY KEY,
+    job_execution_id BIGINT NOT NULL,
+    step_execution_id BIGINT NOT NULL,
+    step_name VARCHAR(100),
+    item_type VARCHAR(50),          -- e.g. "IdentifiableCandidate" or "CandidateEntity"
+    item_public_id TEXT,            -- e.g. a single item or multiple public IDs for a failed chunk
+    error_phase VARCHAR(20),        -- e.g. "PROCESSING" or "WRITING"
+    error_message TEXT,             -- the exception message
+    created_at TIMESTAMP DEFAULT now()
+);

--- a/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
+++ b/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
@@ -1,7 +1,7 @@
 -- V2__create_batch_failed_items_table.sql
 
 CREATE TABLE batch_failed_items (
-    id SERIAL PRIMARY KEY,
+    id BIGINT PRIMARY KEY,
     job_execution_id BIGINT NOT NULL,
     step_execution_id BIGINT NOT NULL,
     step_name VARCHAR(100),
@@ -9,6 +9,6 @@ CREATE TABLE batch_failed_items (
     item_public_id TEXT,            -- e.g. a single item or multiple public IDs for a failed chunk
     error_phase VARCHAR(20),        -- e.g. "PROCESSING" or "WRITING"
     error_message TEXT,             -- the exception message
-    updated_at TIMESTAMP DEFAULT now(),
-    created_at TIMESTAMP DEFAULT now()
+    updated_date TIMESTAMP DEFAULT now(),
+    created_date TIMESTAMP DEFAULT now()
 );

--- a/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
+++ b/src/main/resources/db/migration/V1_31__create_batch_failed_items_table.sql
@@ -9,5 +9,6 @@ CREATE TABLE batch_failed_items (
     item_public_id TEXT,            -- e.g. a single item or multiple public IDs for a failed chunk
     error_phase VARCHAR(20),        -- e.g. "PROCESSING" or "WRITING"
     error_message TEXT,             -- the exception message
+    updated_at TIMESTAMP DEFAULT now(),
     created_at TIMESTAMP DEFAULT now()
 );


### PR DESCRIPTION
This PR:

- Modifies text column type to mirror Postgres db
- Sets up a batch_failed_items table to track batch item failures
- Adds batch failed item entity, repository and service
- Adds spring-boot-starter-validation dependency
- Adds validation to JPA entities
- Configures processing skips on data integrity and validation exceptions
- Introduces a skip listener to process failed item processing or database writes
- Flushes individual item writes to allow partially successful chunks while logging individual item failures

