### PR TITLE
17 add api security to all endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     implementation "org.springframework.boot:spring-boot-starter-batch"
     implementation "org.springframework.boot:spring-boot-starter-validation"
+    implementation "org.springframework.boot:spring-boot-starter-security"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/src/main/java/org/tctalent/anonymization/TcApiServiceApplication.java
+++ b/src/main/java/org/tctalent/anonymization/TcApiServiceApplication.java
@@ -2,15 +2,14 @@ package org.tctalent.anonymization;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 public class TcApiServiceApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(TcApiServiceApplication.class, args);
-
-        //TODO JC Trigger login to server (need app login - ie no MFA)
-        //TODO JC Trigger query of all candidates
     }
 
 }

--- a/src/main/java/org/tctalent/anonymization/config/SecurityConfig.java
+++ b/src/main/java/org/tctalent/anonymization/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.tctalent.anonymization.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,6 +10,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.tctalent.anonymization.security.AuthenticationFilter;
+import org.tctalent.anonymization.security.RestAuthenticationEntryPoint;
 
 /**
  * A configuration class that defines the security filter chain for the application.
@@ -17,16 +19,23 @@ import org.tctalent.anonymization.security.AuthenticationFilter;
  */
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final AuthenticationFilter authenticationFilter;
+  private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(CsrfConfigurer::disable)
         .sessionManagement(httpSecuritySessionManagementConfigurer ->
             httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .addFilterBefore(new AuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-            authorizationManagerRequestMatcherRegistry.requestMatchers("/**").authenticated());
+            authorizationManagerRequestMatcherRegistry.requestMatchers("/**").authenticated())
+        .exceptionHandling(exception ->
+            exception.authenticationEntryPoint(restAuthenticationEntryPoint))
+    ;
 
     return http.build();
   }

--- a/src/main/java/org/tctalent/anonymization/config/SecurityConfig.java
+++ b/src/main/java/org/tctalent/anonymization/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package org.tctalent.anonymization.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.tctalent.anonymization.security.AuthenticationFilter;
+
+/**
+ * A configuration class that defines the security filter chain for the application.
+ *
+ * @author sadatmalik
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(CsrfConfigurer::disable)
+        .sessionManagement(httpSecuritySessionManagementConfigurer ->
+            httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .addFilterBefore(new AuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+        .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+            authorizationManagerRequestMatcherRegistry.requestMatchers("/**").authenticated());
+
+    return http.build();
+  }
+
+}

--- a/src/main/java/org/tctalent/anonymization/security/ApiKeyAuthentication.java
+++ b/src/main/java/org/tctalent/anonymization/security/ApiKeyAuthentication.java
@@ -1,0 +1,45 @@
+package org.tctalent.anonymization.security;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * An ApiKeyAuthentication object that converts the incoming API Key to a Spring Authentication.
+ * The AbstractAuthenticationToken class implements the Spring Authentication interface,
+ * representing the secret/principal for an authenticated request.
+ * <p/>
+ * In Spring Security, an Authentication object typically holds two important pieces of data:
+ * <p/>
+ * Principal: This is the identity of the entity (user, API key, etc.) making the request. In this
+ * particular class, the API key itself is used as the principal.
+ * <p/>
+ * Credentials: These are the secret details used to verify the identity, such as a password or
+ * token. In this implementation, the getCredentials() method returns null because the API key
+ * (which acts as both the identity and the secret) is stored as the principal.
+ * <p/>
+ * In essence, the authentication token is being used to encapsulate the secret (in this case, the
+ * API key) that proves the request’s authenticity, as well as to identify who is making the request.
+ *
+ * @see <a href="https://www.baeldung.com/spring-boot-api-key-secret">
+ * @author sadatmalik
+ */
+public class ApiKeyAuthentication extends AbstractAuthenticationToken {
+  private final String apiKey;
+
+  public ApiKeyAuthentication(String apiKey, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    this.apiKey = apiKey;
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return null;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return apiKey;
+  }
+}

--- a/src/main/java/org/tctalent/anonymization/security/AuthenticationFilter.java
+++ b/src/main/java/org/tctalent/anonymization/security/AuthenticationFilter.java
@@ -1,0 +1,46 @@
+package org.tctalent.anonymization.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+/**
+ * A custom security filter that evaluates the API Key header and set the resulting Authentication
+ * object into the current SecurityContext instance. Then, the request is passed to the remaining
+ * filters for processing and then routed to DispatcherServlet and finally to our controller.
+ * <p/>
+ * We delegate the evaluation of the API Key and constructing the Authentication object to the
+ * AuthenticationService class.
+ *
+ * @see <a href="https://www.baeldung.com/spring-boot-api-key-secret">
+ * @author sadatmalik
+ */
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+  @Override
+  public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws IOException, ServletException {
+    try {
+      Authentication authentication = AuthenticationService.getAuthentication(request);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    } catch (Exception exp) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      PrintWriter writer = response.getWriter();
+      writer.print(exp.getMessage());
+      writer.flush();
+      writer.close();
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+}

--- a/src/main/java/org/tctalent/anonymization/security/AuthenticationService.java
+++ b/src/main/java/org/tctalent/anonymization/security/AuthenticationService.java
@@ -1,0 +1,32 @@
+package org.tctalent.anonymization.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+/**
+ * Authentic Service that checks whether the HTTP request contains the API Key header with a secret
+ * or not. If the header is null or isn’t equal to secret, we throw a BadCredentialsException.
+ * <p/>
+ * If the request has the header, it performs the authentication, adds the secret to the security
+ * context, and then passes the call to the next security filter. Our getAuthentication method is
+ * quite simple – we just compare the API Key header and secret with an encrypted database value.
+ *
+ * @see <a href="https://www.baeldung.com/spring-boot-api-key-secret">
+ * @author sadatmalik
+ */
+public class AuthenticationService {
+
+  private static final String AUTH_TOKEN_HEADER_NAME = "X-API-KEY";
+  private static final String AUTH_TOKEN = "tc-api-xxx-yyy-zzz";
+
+  public static Authentication getAuthentication(HttpServletRequest request) {
+    String apiKey = request.getHeader(AUTH_TOKEN_HEADER_NAME);
+    if (apiKey == null || !apiKey.equals(AUTH_TOKEN)) {
+      throw new BadCredentialsException("Invalid API Key");
+    }
+
+    return new ApiKeyAuthentication(apiKey, AuthorityUtils.NO_AUTHORITIES);
+  }
+}

--- a/src/main/java/org/tctalent/anonymization/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/tctalent/anonymization/security/RestAuthenticationEntryPoint.java
@@ -46,6 +46,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
       AuthenticationException authException) throws IOException, ServletException {
     // Build a ProblemDetails object with 401 status and a custom message
     ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, authException.getMessage());
+    problemDetail.setInstance(URI.create(request.getRequestURI()));
     response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     mapper.writeValue(response.getOutputStream(), problemDetail);

--- a/src/main/java/org/tctalent/anonymization/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/tctalent/anonymization/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package org.tctalent.anonymization.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * An {@link AuthenticationEntryPoint} implementation that handles authentication failures by
+ * returning a Problem Details JSON response compliant with RFC 9457.
+ * <p/>
+ * When an unauthenticated request attempts to access a protected resource, this entry point is
+ * invoked, generating a response with an HTTP 401 (Unauthorized) status and a detailed error
+ * message in the body. The response content type is set to {@code application/problem+json} to
+ * indicate that it conforms to the Problem Details specification.
+ * <p/>
+ * Example response:
+ * <pre>
+ * {
+ *   "type": "about:blank",
+ *   "title": "Unauthorized",
+ *   "status": 401,
+ *   "detail": "Invalid API Key"
+ * }
+ * </pre>
+ * </p>
+ *
+ * @author sadatmalik
+ */
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    // Build a ProblemDetails object with 401 status and a custom message
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, authException.getMessage());
+    response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    mapper.writeValue(response.getOutputStream(), problemDetail);
+  }
+}


### PR DESCRIPTION
This PR:

- Adds spring security depedency
- Implements API key auth 
- Uses standard Spring problem details standard for auth exceptions - see John's comments in #31 

