### PR TITLE
import maven artefact as a gradle dependency in tc-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ There is no need to build the OpenAPI-generated code locally for standard develo
 > 
 > For developers who need to iterate quickly on API spec changes (for example, when working 
 > simultaneously on the spec and the service), please consult the 
-> [OpenAPI Spec Dependency Wiki](https://github.com/Talent-Catalog/tc-api/wiki/OpenAPI-Spec-Dependency) 
+> [Working With the OpenAPI Wiki](https://github.com/Talent-Catalog/tc-api/wiki/Working-with-the-OpenAPI) 
 > for instructions on using local iterative development with `publishToMavenLocal`.
 
 With the Maven artefact in place, you must generate the Mapstruct mapper classes that the service

--- a/README.md
+++ b/README.md
@@ -164,21 +164,23 @@ save the anonymised data to Aurora and Mongo databases.
 
 ### Run the server ###
 
-Before running the server, you must generate the model and api classes that the service needs. The 
-schema for these are defined in the OpenAPI specification in the tc-api-spec which you imported to 
-IntelliJ as an additional module.
+The generated Open API models and controllers are provided in a published Maven artefact 
+(tc-api-spec) that is referenced as a project dependency in the tc-api-service build.gradle file. 
+There is no need to build the OpenAPI-generated code locally for standard development.
 
-From the tc-api root folder, execute the Gradle command: 
+> Developer Note:
+> 
+> For developers who need to iterate quickly on API spec changes (for example, when working 
+> simultaneously on the spec and the service), please consult the 
+> [OpenAPI Spec Dependency Wiki](https://github.com/Talent-Catalog/tc-api/wiki/OpenAPI-Spec-Dependency) 
+> for instructions on using local iterative development with `publishToMavenLocal`.
+
+With the Maven artefact in place, you must generate the Mapstruct mapper classes that the service
+uses to map from TC core data to anonymised candidate data. From the tc-api-service root folder, 
+execute the Gradle command:
 
 ```shell
-./gradlew clean openApiGenerate
-```
-
-Then generate the Mapstruct mapper classes that the service uses to map from TC core data to 
-anonymised candidate data. From the tc-api-service root folder, execute the Gradle command:
-
-```shell
-./gradlew compileJava
+./gradlew clean compileJava
 ```
 
 You can now start the TC API service:

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 sourceSets {
     main {
         java {
-            srcDir "$buildDir/generated/sources/annotationProcessor/java/main"
+            srcDirs = ["src/main/java", "build/generated/sources/annotationProcessor/java/main"]
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 sourceSets {
     main {
         java {
-            srcDirs = ["src/main/java", "build/generated/sources/annotationProcessor/java/main"]
+            srcDirs = ["src/main/java", "$buildDir/generated/sources/annotationProcessor/java/main"]
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-security"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.1"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.2"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ configurations {
 
 // Repositories: Define where dependencies should be resolved from
 repositories {
+    // Use mavenLocal() for local iterative spec and service development
+    // See: https://github.com/Talent-Catalog/tc-api/wiki/OpenAPI-Spec-Dependency
+    //mavenLocal()
     mavenCentral()
 }
 
@@ -46,6 +49,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-batch"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-security"
+
+    // TC open api spec
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.1"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"
@@ -87,53 +93,11 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok-mapstruct-binding:${lombokMapstructBindingVersion}"
 }
 
-// OpenAPI validation task: Validate the OpenAPI specification
-openApiValidate {
-    inputSpec.set(file('../tc-api-spec/openapi.yaml').absolutePath)
-    recommend.set(true)
-}
-
-// OpenAPI generation task: Generate API and model classes from the OpenAPI spec
-openApiGenerate {
-    generatorName.set("spring")
-    inputSpec.set(file('../tc-api-spec/openapi.yaml').absolutePath)
-    outputDir.set("$buildDir/generated")
-    apiPackage.set("org.tctalent.anonymization.api")
-    modelPackage.set("org.tctalent.anonymization.model")
-    configOptions.put("dateLibrary", "java8")
-    configOptions.put("openApiNullable", "false")
-    configOptions.put("useJakartaEe", "true")
-    configOptions.put("useLombokAnnotations", "true")
-    configOptions.put("additionalModelTypeAnnotations", "@lombok.Getter @lombok.Setter")
-    configOptions.put("generateBuilders", "true")
-    library.set("spring-boot")
-    globalProperties.set([
-            modelDocs: "false",
-            apiDocs: "false",
-            apiTests: "false",
-            modelTests: "false",
-            generateAliasAsModel: "true",
-    ])
-
-    // Tell the generator where the custom templates are - e.g. for custom enum code generation
-    templateDir.set(file('../tc-api-spec/custom-templates/JavaSpring').absolutePath)
-}
-
-// Clean-up task: Remove unnecessary generated files
-tasks.named("openApiGenerate").configure {
-    doLast {
-        def generatedMainClass = file("$buildDir/generated/src/main/java/org/openapitools/OpenApiGeneratorApplication.java")
-        if (generatedMainClass.exists()) {
-            generatedMainClass.delete()
-        }
-    }
-}
-
 // Include generated sources in the main source set
 sourceSets {
     main {
         java {
-            srcDir "$buildDir/generated/src/main/java"
+            srcDir "$buildDir/generated/sources/annotationProcessor/java/main"
         }
     }
 }
@@ -142,9 +106,6 @@ sourceSets {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-// Code generation runs before compilation
-compileJava.dependsOn("openApiGenerate")
 
 // Java compilation options
 compileJava {


### PR DESCRIPTION
This PR:

- removes the OpenAPI code generation from the gradle build
- adds a gradle dependency to the OpenAPi generated code artefact in Maven 