### PR TITLE
get the total elements count before modifying the query with pageable options

### DIFF
--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -49,13 +49,15 @@ public class CandidateServiceImpl implements CandidateService {
     filters.forEach((key, values) -> query
         .addCriteria(Criteria.where(key).in(values)));
 
+    //Count the total number of candidates (ie without paging limits).
+    //Get the count before adding the paging because adding that will mutate the query
+    long count = mongoTemplate.count(query, CandidateDocument.class);
+
     //Run the query requesting just the page required
     List<Candidate> candidates = mongoTemplate.find(query.with(pageable), CandidateDocument.class)
             .stream()
             .map(documentMapper::toCandidateModel)
             .toList();
-    //Count the total number of candidates (ie without paging limits).
-    long count = mongoTemplate.count(query, CandidateDocument.class);
 
     //Construct a page
     Page<Candidate> candidatePage = new PageImpl<>(candidates, pageable, count);

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -50,7 +50,8 @@ public class CandidateServiceImpl implements CandidateService {
         .addCriteria(Criteria.where(key).in(values)));
 
     //Count the total number of candidates (ie without paging limits).
-    //Get the count before adding the paging because adding that will mutate the query
+    //Get the count before adding the paging. Adding the paging mutates the query returning the page
+    //count not total count.
     long count = mongoTemplate.count(query, CandidateDocument.class);
 
     //Run the query requesting just the page required


### PR DESCRIPTION
Tiny PR that fixes the totalElements value returned by the find candidates endpoint.