### PR TITLE
70 include employed status candidates in anonymised data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.5"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.6"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.3"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.5"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.2"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.3"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/CandidateController.java
@@ -47,13 +47,13 @@ public class CandidateController implements V1Api {
   @Override
   @PreAuthorize("hasAuthority('READ_CANDIDATE_DATA')")
   public ResponseEntity<CandidatePage> findCandidates(Integer page, Integer limit,
-      String location, String nationality, String occupation) {
+      String location, String nationality, String occupation, Boolean includeEmployed) {
     Pageable pageable = PageRequest.of(page, limit);
 
     //Extract values from comma separated strings of filtering locations, nationalities and
     //occupations
     CandidatePage candidatesPage = candidateService.findAll(pageable,
-        split(location), split(nationality), split(occupation));
+        split(location), split(nationality), split(occupation), includeEmployed);
     return ResponseEntity.ok(candidatesPage);
   }
 

--- a/src/main/java/org/tctalent/anonymization/service/CandidateService.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateService.java
@@ -21,7 +21,8 @@ public interface CandidateService {
   CandidatePage findAll(Pageable pageable,
       @Nullable List<String> locations,
       @Nullable List<String> nationalities,
-      @Nullable List<String> occupations);
+      @Nullable List<String> occupations,
+      @Nullable Boolean includeEmployed);
 
   /**
    * Returns candidate associated with given id

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -29,7 +29,7 @@ public class CandidateServiceImpl implements CandidateService {
 
   @Override
   public CandidatePage findAll(Pageable pageable, List<String> locations,
-      List<String> nationalities, List<String> occupations) {
+      List<String> nationalities, List<String> occupations, Boolean includeEmployed) {
 
     Map<String, List<String>> filters = new HashMap<>();
     if (locations != null) {
@@ -49,13 +49,22 @@ public class CandidateServiceImpl implements CandidateService {
     filters.forEach((key, values) -> query
         .addCriteria(Criteria.where(key).in(values)));
 
+
+    // If includeEmployed is null or false, exclude candidates with status "employed"
+    if (includeEmployed == null || includeEmployed.equals(Boolean.FALSE)) {
+      query.addCriteria(Criteria.where("status").ne("employed"));
+    }
+
+    //Count the total number of candidates (ie without paging limits).
+    //Get the count before adding the paging. Adding the paging mutates the query returning the page
+    //count not total count.
+    long count = mongoTemplate.count(query, CandidateDocument.class);
+
     //Run the query requesting just the page required
     List<Candidate> candidates = mongoTemplate.find(query.with(pageable), CandidateDocument.class)
             .stream()
             .map(documentMapper::toCandidateModel)
             .toList();
-    //Count the total number of candidates (ie without paging limits).
-    long count = mongoTemplate.count(query, CandidateDocument.class);
 
     //Construct a page
     Page<Candidate> candidatePage = new PageImpl<>(candidates, pageable, count);

--- a/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/CandidateServiceImpl.java
@@ -51,7 +51,7 @@ public class CandidateServiceImpl implements CandidateService {
 
 
     // If includeEmployed is null or false, exclude candidates with status "employed"
-    if (includeEmployed == null || includeEmployed.equals(Boolean.FALSE)) {
+    if (!Boolean.TRUE.equals(includeEmployed)) {
       query.addCriteria(Criteria.where("status").ne("employed"));
     }
 

--- a/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
+++ b/src/test/java/org/tctalent/anonymization/controller/CandidateControllerTest.java
@@ -40,7 +40,7 @@ class CandidateControllerTest {
         .build();
 
     Pageable pageable = PageRequest.of(0, 10);
-    testCandidate = candidateService.findAll(pageable, null, null, null).getContent().iterator().next();
+    testCandidate = candidateService.findAll(pageable, null, null, null, null).getContent().iterator().next();
   }
 
   @Test

--- a/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/CandidateServiceImplTest.java
@@ -5,16 +5,19 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Optional;
+import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.tctalent.anonymization.domain.document.CandidateDocument;
 import org.tctalent.anonymization.mapper.DocumentMapper;
 import org.tctalent.anonymization.model.Candidate;
@@ -25,6 +28,7 @@ class CandidateServiceImplTest {
 
   @Mock private CandidateDocumentRepository candidateDocumentRepository;
   @Mock private DocumentMapper documentMapper;
+  @Mock private MongoTemplate mongoTemplate;
 
   @InjectMocks private CandidateServiceImpl candidateService;
 
@@ -37,24 +41,151 @@ class CandidateServiceImplTest {
   @DisplayName("Test find all candidates")
   void testFindAll() {
     Pageable pageable = PageRequest.of(0, 10);
-    Page<CandidateDocument> candidateDocumentPage = new PageImpl<>(List.of(new CandidateDocument()));
+    CandidateDocument candidateDocument = new CandidateDocument();
+    List<CandidateDocument> candidateDocuments = List.of(candidateDocument);
     Candidate candidate = new Candidate();
-    Page<Candidate> candidatePage = new PageImpl<>(List.of(candidate));
     CandidatePage expectedCandidatePage = new CandidatePage();
 
-    when(candidateDocumentRepository
-        .findAll(pageable))
-        .thenReturn(candidateDocumentPage);
+    when(mongoTemplate
+        .find(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn(candidateDocuments);
+
+    when(mongoTemplate
+        .count(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn((long) candidateDocuments.size());
+
+    when(documentMapper.toCandidateModel(any(CandidateDocument.class)))
+        .thenReturn(candidate);
+
+    when(documentMapper.toCandidateModelPage(any(Page.class)))
+        .thenReturn(expectedCandidatePage);
+
+    // includeEmployed set to false: should add a criteria excluding employed candidates.
+    CandidatePage result = candidateService.findAll(pageable, null, null, null, null);
+
+    // Capture and verify the query passed to mongoTemplate.find
+    ArgumentCaptor<Query> findQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).find(findQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the find query includes a filter: status != "employed"
+    Query usedFindQuery = findQueryCaptor.getValue();
+    Document findQueryObject = usedFindQuery.getQueryObject();
+    assertTrue(findQueryObject.containsKey("status"), "Expected query to contain a 'status' filter");
+    Document statusCriteria = (Document) findQueryObject.get("status");
+    assertEquals("employed", statusCriteria.get("$ne"), "Expected $ne criteria to be 'employed'");
+
+    // Capture and verify the query passed to mongoTemplate.count
+    ArgumentCaptor<Query> countQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).count(countQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the count query has the same filter
+    Query usedCountQuery = countQueryCaptor.getValue();
+    Document countQueryObject = usedCountQuery.getQueryObject();
+    assertTrue(countQueryObject.containsKey("status"), "Expected count query to contain a 'status' filter");
+    Document countStatusCriteria = (Document) countQueryObject.get("status");
+    assertEquals("employed", countStatusCriteria.get("$ne"), "Expected count query $ne criteria to be 'employed'");
+
+    assertNotNull(result);
+    assertEquals(expectedCandidatePage, result);
+  }
+
+  @Test
+  @DisplayName("Test find all candidates excluding employed candidates")
+  void testFindAll_ExcludesEmployed() {
+    Pageable pageable = PageRequest.of(0, 10);
+    CandidateDocument candidateDocument = new CandidateDocument();
+    List<CandidateDocument> candidateDocuments = List.of(candidateDocument);
+    Candidate candidate = new Candidate();
+    CandidatePage expectedCandidatePage = new CandidatePage();
+
+    when(mongoTemplate
+        .find(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn(candidateDocuments);
+
+    when(mongoTemplate
+        .count(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn((long) candidateDocuments.size());
+
+    when(documentMapper.toCandidateModel(any(CandidateDocument.class)))
+        .thenReturn(candidate);
+
+    when(documentMapper.toCandidateModelPage(any(Page.class)))
+        .thenReturn(expectedCandidatePage);
+
+    // includeEmployed set to false: should add a criteria excluding employed candidates.
+    CandidatePage result = candidateService.findAll(pageable, null, null, null, false);
+
+    // Capture and verify the query passed to mongoTemplate.find
+    ArgumentCaptor<Query> findQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).find(findQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the find query includes a filter: status != "employed"
+    Query usedFindQuery = findQueryCaptor.getValue();
+    Document findQueryObject = usedFindQuery.getQueryObject();
+    assertTrue(findQueryObject.containsKey("status"), "Expected query to contain a 'status' filter");
+    Document statusCriteria = (Document) findQueryObject.get("status");
+    assertEquals("employed", statusCriteria.get("$ne"), "Expected $ne criteria to be 'employed'");
+
+    // Capture and verify the query passed to mongoTemplate.count
+    ArgumentCaptor<Query> countQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).count(countQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the count query has the same filter
+    Query usedCountQuery = countQueryCaptor.getValue();
+    Document countQueryObject = usedCountQuery.getQueryObject();
+    assertTrue(countQueryObject.containsKey("status"), "Expected count query to contain a 'status' filter");
+    Document countStatusCriteria = (Document) countQueryObject.get("status");
+    assertEquals("employed", countStatusCriteria.get("$ne"), "Expected count query $ne criteria to be 'employed'");
+
+    assertNotNull(result);
+    assertEquals(expectedCandidatePage, result);
+  }
+
+  @Test
+  @DisplayName("Test find all candidates including employed candidates")
+  void testFindAll_IncludesEmployed() {
+    Pageable pageable = PageRequest.of(0, 10);
+    CandidateDocument candidateDocument = new CandidateDocument();
+    List<CandidateDocument> candidateDocuments = List.of(candidateDocument);
+    Candidate candidate = new Candidate();
+    CandidatePage expectedCandidatePage = new CandidatePage();
+
+    when(mongoTemplate
+        .find(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn(candidateDocuments);
+
+    when(mongoTemplate
+        .count(any(Query.class), eq(CandidateDocument.class)))
+        .thenReturn((long) candidateDocuments.size());
 
     when(documentMapper
         .toCandidateModel(any(CandidateDocument.class)))
         .thenReturn(candidate);
 
     when(documentMapper
-        .toCandidateModelPage(candidatePage))
+        .toCandidateModelPage(any(Page.class)))
         .thenReturn(expectedCandidatePage);
 
-    CandidatePage result = candidateService.findAll(pageable, null, null, null);
+    // includeEmployed set to true: should not add a criteria to exclude employed candidates.
+    CandidatePage result = candidateService.findAll(pageable, null, null, null, true);
+
+    // Capture and verify the query passed to mongoTemplate.find
+    ArgumentCaptor<Query> findQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).find(findQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the find query does not include status filter
+    Query usedFindQuery = findQueryCaptor.getValue();
+    Document findQueryObject = usedFindQuery.getQueryObject();
+    assertFalse(findQueryObject.containsKey("status"), "Expected query to not contain a 'status' filter when including employed");
+
+    // Capture and verify the query passed to mongoTemplate.count
+    ArgumentCaptor<Query> countQueryCaptor = ArgumentCaptor.forClass(Query.class);
+    verify(mongoTemplate).count(countQueryCaptor.capture(), eq(CandidateDocument.class));
+
+    // Verify that the count query does not include status filter
+    Query usedCountQuery = countQueryCaptor.getValue();
+    Document countQueryObject = usedCountQuery.getQueryObject();
+    assertFalse(countQueryObject.containsKey("status"), "Expected count query to not contain a 'status' filter when including employed");
 
     assertNotNull(result);
     assertEquals(expectedCandidatePage, result);

--- a/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/TalentCatalogServiceImplTest.java
@@ -45,6 +45,9 @@ class TalentCatalogServiceImplTest {
   @Test
   void fetchPageOfCandidateDataAsJson() {
     try {
+      tcService.login();
+      assertTrue(tcService.isLoggedIn());
+
       String pageOfDataAsJson = tcService.fetchPageOfCandidateDataAsJson(0);
       assertNotNull(pageOfDataAsJson);
     } catch (RestClientException ex) {


### PR DESCRIPTION
This PR adds an include employed status query param to the find candidates endpoint + unit tests