### PR TITLE
correctly sets the candidate_id on candidate_job_experiences

### DIFF
--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateJobExperience.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateJobExperience.java
@@ -21,6 +21,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.Valid;
@@ -41,6 +43,22 @@ public class CandidateJobExperience extends AbstractDomainEntity<Long> {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "candidate_id")
     private CandidateEntity candidate;
+
+    /**
+     * Synchronizes the candidate field with the candidate obtained from the associated
+     * CandidateOccupation.
+     * <p>
+     * This method is automatically invoked before the entity is persisted or updated so that the
+     * candidate_id column in the candidate_job_experience table is correctly populated.
+     * </p>
+     */
+    @PrePersist
+    @PreUpdate
+    private void syncCandidate() {
+        if (this.candidateOccupation != null) {
+            this.candidate = this.candidateOccupation.getCandidate();
+        }
+    }
 
     // Store the isoCode directly instead of a foreign key reference
     @Size(max = 3)

--- a/src/main/java/org/tctalent/anonymization/domain/entity/CandidateOccupation.java
+++ b/src/main/java/org/tctalent/anonymization/domain/entity/CandidateOccupation.java
@@ -62,10 +62,7 @@ public class CandidateOccupation extends AbstractDomainEntity<Long> {
 
     public void setCandidateJobExperiences(List<CandidateJobExperience> experiences) {
         this.candidateJobExperiences.clear();
-        experiences.forEach(experience -> {
-            experience.setCandidateOccupation(this);
-            experience.setCandidate(candidate);
-        });
+        experiences.forEach(experience -> experience.setCandidateOccupation(this));
         this.candidateJobExperiences.addAll(experiences);
     }
 


### PR DESCRIPTION
Small PR that fixes a bug where candidate_id values were not being correctly set when creating or updating a candidate_job_experience