### PR TITLE
configure s3 bucket and mongo atlas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.6"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.7"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -172,11 +172,12 @@ module "ecs_service" {
       client_aliases = []
     }]
 
-    client_services = [{
-      discovery_name = "mongo"
-      port           = 27017
-      dns_name       = "mongo"
-    }]
+    # MODEL - This block is an example of discovering other ECS services
+    # client_services = [{
+    #   discovery_name = "mongo"
+    #   port           = 27017
+    #   dns_name       = "mongo"
+    # }]
   }
 
   load_balancer = {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -207,7 +207,7 @@ module "ecs_service" {
   }
 
   service_tags = {
-    "ServiceTag" = "Tag on service level"
+    Name = "${local.name}-service"
   }
 
   tags = local.tags

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,16 +1,6 @@
 # Use standard Terraform AWS modules where possible.
 # See https://registry.terraform.io/browse/modules?provider=aws
 
-# todo Store state on s3 so shared by everyone
-# terraform {
-#   backend "s3" {
-#     bucket         = "my-terraform-state"
-#     key            = "state/terraform.tfstate"
-#     region         = "us-east-1"
-#     encrypt        = true
-#   }
-# }
-
 # todo Use secrets manager
 
 provider "aws" {

--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -22,7 +22,7 @@ module tc-prod {
 
 terraform {
   backend "s3" {
-    bucket         = "tc-api-terraform-state"
+    bucket         = "tc-api-terraform-state-prod"
     key            = "state/terraform.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -10,7 +10,8 @@ module tc-prod {
   db_instance_class = "db.t3.medium" # 2vCPU, 4GB RAM
   doc_db_name = "tcapi"
   doc_db_user_name = "tcapi"
-  doc_db_service_name = "mongo"
+  doc_db_password = ""
+  doc_db_cluster_name = "prod.t9anmq2.mongodb.net"
   dns_namespace = "tc-api.local"
   app_port = 8082
   health_check_path = "/actuator/health"

--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -19,3 +19,12 @@ module tc-prod {
   tc_api_username = "tc-api"
   run_anonymisation_on_startup = false
 }
+
+terraform {
+  backend "s3" {
+    bucket         = "tc-api-terraform-state"
+    key            = "state/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -10,7 +10,8 @@ module tc-test {
   db_instance_class = "db.t3.medium" # smallest test instance available for aurora
   doc_db_name = "tcapi"
   doc_db_user_name = "tcapi"
-  doc_db_service_name = "mongo"
+  doc_db_password = ""
+  doc_db_cluster_name = "staging.c8pam.mongodb.net"
   dns_namespace = "tc-api.local"
   app_port = 8082
   health_check_path = "/actuator/health"

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -17,7 +17,7 @@ module tc-test {
   tc_api_url = "https://tctalent-test.org/api/admin"
   tc_api_search_id = 2682
   tc_api_username = "tc-api"
-  run_anonymisation_on_startup = true
+  run_anonymisation_on_startup = false
 }
 
 terraform {

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -19,3 +19,12 @@ module tc-test {
   tc_api_username = "tc-api"
   run_anonymisation_on_startup = true
 }
+
+terraform {
+  backend "s3" {
+    bucket         = "tc-api-terraform-state"
+    key            = "state/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -49,8 +49,12 @@ variable "doc_db_user_name" {
   description = "Doc data base user name"
 }
 
-variable "doc_db_service_name" {
-  description = "DNS name of the document database"
+variable "doc_db_password" {
+  description = "Doc data base password"
+}
+
+variable "doc_db_cluster_name" {
+  description = "Cluster name of the document database"
 }
 
 variable "dns_namespace" {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ spring:
     jdbc:
       initialize-schema: never # batch schema are initialised by flyway
     job:
-      enabled: ${SPRING_BATCH_JOB_ENABLED:false} # enable/disable auto-run of jobs
+      enabled: ${SPRING_BATCH_JOB_ENABLED:true} # enable/disable auto-run of jobs
 
 # Actuator
 management:


### PR DESCRIPTION
This PR:

- configures s3 for shared terraform state
- includes a minor update to correctly set service tags

It additionally includes changes required for setting up Mongo Atlas:

- removes the self managed Mongo service, storage, dns entries
- points the tc-api service directly to the mongo atlas clusters (for staging)