### PR TITLE
rename the api load balancers and use https

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -376,6 +376,12 @@ module "alb" {
       ip_protocol = "tcp"
       cidr_ipv4   = "0.0.0.0/0"
     }
+    https = {
+      from_port   = 443
+      to_port     = 443
+      ip_protocol = "tcp"
+      cidr_ipv4   = "0.0.0.0/0"
+    }
   }
   security_group_egress_rules = {
     all = {
@@ -388,6 +394,18 @@ module "alb" {
     ex_http = {
       port     = 80
       protocol = "HTTP"
+
+      redirect = {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+    ex_https = {
+      port            = 443
+      protocol        = "HTTPS"
+      ssl_policy      = "ELBSecurityPolicy-2016-08"
+      certificate_arn = var.acm_certificate_arn
 
       forward = {
         target_group_key = "ex_ecs"

--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -19,6 +19,7 @@ module tc-prod {
   tc_api_search_id = 3434
   tc_api_username = "tc-api"
   run_anonymisation_on_startup = false
+  acm_certificate_arn = "arn:aws:acm:us-east-1:968457613372:certificate/5dd8d298-5460-4396-ad5e-24e3a2dfa774"
 }
 
 terraform {

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -19,6 +19,7 @@ module tc-test {
   tc_api_search_id = 2682
   tc_api_username = "tc-api"
   run_anonymisation_on_startup = false
+  acm_certificate_arn = "arn:aws:acm:us-east-1:231168606641:certificate/3a502945-f505-46f9-aa08-523c2be2593d"
 }
 
 terraform {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -86,3 +86,7 @@ variable "tc_api_username" {
 variable "run_anonymisation_on_startup" {
   description = "If true run the DB anonymisation on startup"
 }
+
+variable "acm_certificate_arn" {
+  description = "The ARN of an ACM certificate"
+}


### PR DESCRIPTION
This PR -

- Establishes https access for the API service
- Forwards http:// requests to https://
- Configures SSL certs in the Terraform deployment (staging and prod)