### PR TITLE
87 use latest tc api spec v1.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     // TC open api spec
-    implementation "io.github.sadatmalik:tc-api-spec:1.0.8"
+    implementation "io.github.sadatmalik:tc-api-spec:1.0.11"
 
     // Database drivers and migration tools
     runtimeOnly "org.postgresql:postgresql"

--- a/src/main/java/org/tctalent/anonymization/mapper/DateTimeMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/DateTimeMapper.java
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.mapstruct.Mapper;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface DateTimeMapper {
 
   default OffsetDateTime toOffsetDateTime(Instant instant) {

--- a/src/main/java/org/tctalent/anonymization/mapper/DocumentMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/DocumentMapper.java
@@ -14,9 +14,10 @@ import org.tctalent.anonymization.domain.document.CandidateDocument;
 import org.tctalent.anonymization.model.IdentifiableCandidateVisaJobCheck;
 import org.tctalent.anonymization.model.IdentifiableDependant;
 
-@Mapper(uses = {
-    DateTimeMapper.class
-})
+@Mapper(
+    componentModel = "spring",
+    uses = {DateTimeMapper.class}
+)
 public interface DocumentMapper {
 
   /**

--- a/src/main/java/org/tctalent/anonymization/mapper/EntityMapper.java
+++ b/src/main/java/org/tctalent/anonymization/mapper/EntityMapper.java
@@ -27,7 +27,10 @@ import org.tctalent.anonymization.model.LanguageLevel;
 import org.tctalent.anonymization.model.Occupation;
 import org.tctalent.anonymization.model.SurveyType;
 
-@Mapper(uses = {})
+@Mapper(
+    componentModel = "spring",
+    uses = {}
+)
 public interface EntityMapper {
 
   @Mapping(target = "id", ignore = true)


### PR DESCRIPTION
This PR updates the api spec version to the latest 1.0.11 and sets the component model to spring on mapstruct mapper for local builds.