### PR TITLE
90 triggering an api batch job execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 // Project metadata: Group and version details
 group = 'org.tctalent'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.1-SNAPSHOT'
 
 // Java toolchain configuration
 java {

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -13,6 +13,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+/**
+ * REST controller that exposes endpoints for managing and running batch jobs.
+ * <p>
+ * Provides an endpoint to launch a candidate anonymisation job. Only one job instance runs per day
+ * by including the current date as a unique job parameter. Access to the endpoint is secured with
+ * an 'ADMIN' authority.
+ *
+ * @author sadatmalik
+ */
 @RestController
 @RequestMapping("/batch")
 public class BatchJobController {
@@ -29,7 +39,14 @@ public class BatchJobController {
   }
 
   /**
-   * Launch a candidate anonymisation job.
+   * Launches the candidate anonymisation batch job.
+   * <p>
+   * A unique job parameter "jobDate" is added based on the current date to enforce a single job
+   * instance per day. The endpoint is secured and only accessible to users with the 'ADMIN'
+   * authority.
+   *
+   * @return a ResponseEntity with a success message if the job is launched successfully
+   * @throws JobExecutionException if the job launch fails
    */
   @PreAuthorize("hasAuthority('ADMIN')")
   @PostMapping("/jobs/run")

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -1,12 +1,12 @@
 package org.tctalent.anonymization.controller;
 
 import java.time.LocalDate;
-import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,11 +15,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/batch")
-@RequiredArgsConstructor
 public class BatchJobController {
 
-  private final JobLauncher jobLauncher;
+  private final JobLauncher asyncJobLauncher;
   private final Job candidateMigrationJob;
+
+  public BatchJobController(
+      @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
+      @Qualifier("candidateMigrationJob") Job candidateMigrationJob) {
+
+    this.asyncJobLauncher = asyncJobLauncher;
+    this.candidateMigrationJob = candidateMigrationJob;
+  }
 
   /**
    * Launch a candidate anonymisation job.
@@ -34,7 +41,7 @@ public class BatchJobController {
           .addString("jobDate", LocalDate.now().toString()) // e.g., "2025-04-15"
           .toJobParameters();
 
-      jobLauncher.run(candidateMigrationJob, params);
+      asyncJobLauncher.run(candidateMigrationJob, params);
 
       return ResponseEntity.ok("Job '" + candidateMigrationJob.getName() + "' launched successfully.");
 

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -1,0 +1,46 @@
+package org.tctalent.anonymization.controller;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/batch")
+@RequiredArgsConstructor
+public class BatchJobController {
+
+  private final JobLauncher jobLauncher;
+  private final Job candidateMigrationJob;
+
+  /**
+   * Launch a candidate anonymisation job.
+   */
+  @PreAuthorize("hasAuthority('ADMIN')")
+  @PostMapping("/jobs/run")
+  public ResponseEntity<String> runJob() throws Exception{
+    try {
+      // Job params must be unique per job execution, if not the job will not run
+      // We enforce a max of one job instance per day by setting a date parameter
+      JobParameters params = new JobParametersBuilder()
+          .addString("jobDate", LocalDate.now().toString()) // e.g., "2025-04-15"
+          .toJobParameters();
+
+      jobLauncher.run(candidateMigrationJob, params);
+
+      return ResponseEntity.ok("Job '" + candidateMigrationJob.getName() + "' launched successfully.");
+
+    } catch (Exception e) {
+      throw new JobExecutionException("Job launch failed: " + e.getMessage());
+    }
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ spring:
     jdbc:
       initialize-schema: never # batch schema are initialised by flyway
     job:
-      enabled: ${SPRING_BATCH_JOB_ENABLED:true} # enable/disable auto-run of jobs
+      enabled: ${SPRING_BATCH_JOB_ENABLED:false} # enable/disable auto-run of jobs
 
 # Actuator
 management:


### PR DESCRIPTION
This PR -

- Sets the tc-api version to 1.0.1-SNAPSHOT
- Implements a batch job controller
- Adds an asynchronous job launcher to launch jobs via batch controller endpoints
- Sets the batch.job.enabled to false so that jobs will no longer automatically commence on service startup