### PR TITLE
use tc-api 1.0.1-SNAPSHOT in terraform test and prod builds

### DIFF
--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -2,7 +2,7 @@ module tc-prod {
   source = "./.."
   project_name = "tc-api"
   project_description = "Production setup for tc-api"
-  image_tag = "1.0.0"
+  image_tag = "1.0.1-SNAPSHOT"
   fargate_cpu = 512
   fargate_memory = 2048
   db_name = "tcapi"

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -2,7 +2,7 @@ module tc-test {
   source = "./.."
   project_name = "tc-api"
   project_description = "Staging setup for tc-api"
-  image_tag = "0.0.1-SNAPSHOT"
+  image_tag = "1.0.1-SNAPSHOT"
   fargate_cpu = 512
   fargate_memory = 2048
   db_name = "tcapi"


### PR DESCRIPTION
Small PR that updates the tc-api terraform image tag in test and prod to match the Gradle build tag