### PR TITLE
browse stop and restart failed jobs

### DIFF
--- a/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
+++ b/src/main/java/org/tctalent/anonymization/batch/config/BatchConfig.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.launch.support.SimpleJobOperator;
 import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -188,6 +192,23 @@ public class BatchConfig {
     jobLauncher.setTaskExecutor(new SimpleAsyncTaskExecutor());
     jobLauncher.afterPropertiesSet();
     return jobLauncher;
+  }
+
+  @Bean
+  @Qualifier("asyncJobOperator")
+  public JobOperator asyncJobOperator(JobExplorer jobExplorer,
+      JobRepository jobRepository,
+      JobRegistry jobRegistry,
+      @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher) throws Exception {
+
+    SimpleJobOperator jobOperator = new SimpleJobOperator();
+    jobOperator.setJobExplorer(jobExplorer);
+    jobOperator.setJobRepository(jobRepository);
+    jobOperator.setJobRegistry(jobRegistry);
+    jobOperator.setJobLauncher(asyncJobLauncher);  // Using the async job launcher
+    jobOperator.afterPropertiesSet();
+
+    return jobOperator;
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -5,6 +5,7 @@ import org.springframework.batch.core.JobExecutionException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,6 +51,20 @@ public class BatchJobController {
   public ResponseEntity<String> getJobExecutions() {
     String summary = batchJobService.getJobExecutionsSummary();
     return ResponseEntity.ok(summary);
+  }
+
+  /**
+   * Attempts to stop a running job execution.
+   *
+   * @param executionId the ID of the job execution to stop
+   * @return a ResponseEntity containing a message indicating whether the stop request was initiated successfully.
+   * @throws Exception if the stop operation fails (e.g. invalid execution ID or internal error)
+   */
+  @PreAuthorize("hasAuthority('ADMIN')")
+  @PostMapping("/jobs/{executionId}/stop")
+  public ResponseEntity<String> stopJobExecution(@PathVariable Long executionId) throws Exception {
+    String message = batchJobService.stopJobExecution(executionId);
+    return ResponseEntity.ok(message);
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -68,7 +68,7 @@ public class BatchJobController {
   }
 
   /**
-   * Attempts to restart a failed job execution.
+   * Attempts to restart a job execution.
    *
    * @param executionId the ID of the failed job execution to restart
    * @return a 200 OK response with a message including the new execution ID

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -1,59 +1,34 @@
 package org.tctalent.anonymization.controller;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobExecution;
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.JobExecutionException;
-import org.springframework.batch.core.JobInstance;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.explore.JobExplorer;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.tctalent.anonymization.service.BatchJobService;
 
 
 /**
  * REST controller that exposes endpoints for managing and running batch jobs.
  * <p>
- * Provides an endpoint to launch a candidate anonymisation job. Only one job instance runs per day
- * by including the current date as a unique job parameter. Access to the endpoint is secured with
- * an 'ADMIN' authority.
+ * Provides endpoints to launch a candidate anonymisation job and retrieve job executions.
+ * <p>
+ * Access to endpoints is secured with an 'ADMIN' authority.
  *
  * @author sadatmalik
  */
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/batch")
 public class BatchJobController {
 
-  private final JobLauncher asyncJobLauncher;
-  private final Job candidateMigrationJob;
-  private final JobExplorer jobExplorer;
-
-
-  public BatchJobController(
-      @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
-      @Qualifier("candidateMigrationJob") Job candidateMigrationJob,
-      JobExplorer jobExplorer) {
-
-    this.asyncJobLauncher = asyncJobLauncher;
-    this.candidateMigrationJob = candidateMigrationJob;
-    this.jobExplorer = jobExplorer;
-  }
+  private final BatchJobService batchJobService;
 
   /**
-   * Launches the candidate anonymisation batch job.
-   * <p>
-   * A unique job parameter "jobDate" is added based on the current date to enforce a single job
-   * instance per day. The endpoint is secured and only accessible to users with the 'ADMIN'
-   * authority.
+   * Launches the candidate anonymisation batch job (one run per day).
    *
    * @return a ResponseEntity with a success message if the job is launched successfully
    * @throws JobExecutionException if the job launch fails
@@ -61,68 +36,20 @@ public class BatchJobController {
   @PreAuthorize("hasAuthority('ADMIN')")
   @PostMapping("/jobs/run")
   public ResponseEntity<String> runJob() throws Exception{
-    try {
-      // Job params must be unique per job execution, if not the job will not run
-      // We enforce a max of one job instance per day by setting a date parameter
-      JobParameters params = new JobParametersBuilder()
-          .addString("jobDate", LocalDate.now().toString()) // e.g., "2025-04-15"
-          .toJobParameters();
-
-      asyncJobLauncher.run(candidateMigrationJob, params);
-
-      return ResponseEntity.ok("Job '" + candidateMigrationJob.getName() + "' launched successfully.");
-
-    } catch (Exception e) {
-      throw new JobExecutionException("Job launch failed: " + e.getMessage());
-    }
+    String message = batchJobService.runCandidateMigrationJob();
+    return ResponseEntity.ok(message);
   }
 
   /**
-   * Retrieves summaries of recent batch job executions across all job instances.
-   * Each entry contains execution ID, job name, status, start/end times, and parameters.
+   * Returns a plain-text list of recent job executions.
    *
    * @return a list of JobExecutionInfo DTOs
    */
   @PreAuthorize("hasAuthority('ADMIN')")
   @GetMapping("/jobs")
   public ResponseEntity<String> getJobExecutions() {
-    StringBuilder sb = new StringBuilder();
-
-    for (String jobName : jobExplorer.getJobNames()) {
-      // fetch up to 20 recent instances
-      List<JobInstance> instances = jobExplorer.getJobInstances(jobName, 0, 20);
-      for (JobInstance instance : instances) {
-        for (JobExecution exec : jobExplorer.getJobExecutions(instance)) {
-          sb.append(formatExecution(exec));
-        }
-      }
-    }
-
-    String result = !sb.isEmpty() ? sb.toString() : "No job executions found.\n";
-    return ResponseEntity.ok(result);
-  }
-
-  /**
-   * Formats a single JobExecution as: [<executionId>] <jobName> <status> <startTime> - <endTime>
-   */
-  private String formatExecution(JobExecution exec) {
-    return "["
-        + exec.getId()
-        + "] "
-        + exec.getJobInstance().getJobName()
-        + " "
-        + exec.getStatus()
-        + " "
-        + formatDate(exec.getStartTime())
-        + " - "
-        + formatDate(exec.getEndTime())
-        + "\n";
-  }
-
-  private String formatDate(LocalDateTime date) {
-    return date == null
-        ? "null"
-        : date.toString();
+    String summary = batchJobService.getJobExecutionsSummary();
+    return ResponseEntity.ok(summary);
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -1,14 +1,20 @@
 package org.tctalent.anonymization.controller;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,13 +35,17 @@ public class BatchJobController {
 
   private final JobLauncher asyncJobLauncher;
   private final Job candidateMigrationJob;
+  private final JobExplorer jobExplorer;
+
 
   public BatchJobController(
       @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
-      @Qualifier("candidateMigrationJob") Job candidateMigrationJob) {
+      @Qualifier("candidateMigrationJob") Job candidateMigrationJob,
+      JobExplorer jobExplorer) {
 
     this.asyncJobLauncher = asyncJobLauncher;
     this.candidateMigrationJob = candidateMigrationJob;
+    this.jobExplorer = jobExplorer;
   }
 
   /**
@@ -65,6 +75,54 @@ public class BatchJobController {
     } catch (Exception e) {
       throw new JobExecutionException("Job launch failed: " + e.getMessage());
     }
+  }
+
+  /**
+   * Retrieves summaries of recent batch job executions across all job instances.
+   * Each entry contains execution ID, job name, status, start/end times, and parameters.
+   *
+   * @return a list of JobExecutionInfo DTOs
+   */
+  @PreAuthorize("hasAuthority('ADMIN')")
+  @GetMapping("/jobs")
+  public ResponseEntity<String> getJobExecutions() {
+    StringBuilder sb = new StringBuilder();
+
+    for (String jobName : jobExplorer.getJobNames()) {
+      // fetch up to 20 recent instances
+      List<JobInstance> instances = jobExplorer.getJobInstances(jobName, 0, 20);
+      for (JobInstance instance : instances) {
+        for (JobExecution exec : jobExplorer.getJobExecutions(instance)) {
+          sb.append(formatExecution(exec));
+        }
+      }
+    }
+
+    String result = !sb.isEmpty() ? sb.toString() : "No job executions found.\n";
+    return ResponseEntity.ok(result);
+  }
+
+  /**
+   * Formats a single JobExecution as: [<executionId>] <jobName> <status> <startTime> - <endTime>
+   */
+  private String formatExecution(JobExecution exec) {
+    return "["
+        + exec.getId()
+        + "] "
+        + exec.getJobInstance().getJobName()
+        + " "
+        + exec.getStatus()
+        + " "
+        + formatDate(exec.getStartTime())
+        + " - "
+        + formatDate(exec.getEndTime())
+        + "\n";
+  }
+
+  private String formatDate(LocalDateTime date) {
+    return date == null
+        ? "null"
+        : date.toString();
   }
 
 }

--- a/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
+++ b/src/main/java/org/tctalent/anonymization/controller/BatchJobController.java
@@ -67,4 +67,18 @@ public class BatchJobController {
     return ResponseEntity.ok(message);
   }
 
+  /**
+   * Attempts to restart a failed job execution.
+   *
+   * @param executionId the ID of the failed job execution to restart
+   * @return a 200 OK response with a message including the new execution ID
+   * @throws Exception if the restart fails (e.g. if the job isn't restartable)
+   */
+  @PreAuthorize("hasAuthority('ADMIN')")
+  @PostMapping("/jobs/{executionId}/restart")
+  public ResponseEntity<String> restartJobExecution(@PathVariable Long executionId) throws Exception {
+    String message = batchJobService.restartJobExecution(executionId);
+    return ResponseEntity.ok(message);
+  }
+
 }

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
@@ -1,0 +1,25 @@
+package org.tctalent.anonymization.service;
+
+import org.springframework.batch.core.JobExecutionException;
+
+/**
+ * Service interface for managing and running Spring Batch jobs.
+ * <p>
+ * Provides operations to launch the candidate anonymisation job and to retrieve a plain-text
+ * summary of recent job executions.
+ * </p>
+ */
+public interface BatchJobService {
+
+  /**
+   * Launches the candidateMigrationJob.
+   * Returns a confirmation message or throws on failure.
+   */
+  String runCandidateMigrationJob() throws JobExecutionException;
+
+  /**
+   * Builds a plain-text summary of job executions.
+   */
+  String getJobExecutionsSummary();
+
+ }

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
@@ -27,4 +27,9 @@ public interface BatchJobService {
    */
   String stopJobExecution(Long executionId) throws Exception;
 
+  /**
+   * Attempts to restart a failed job execution by ID.
+   */
+  String restartJobExecution(Long executionId) throws Exception;
+
 }

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
@@ -28,7 +28,7 @@ public interface BatchJobService {
   String stopJobExecution(Long executionId) throws Exception;
 
   /**
-   * Attempts to restart a failed job execution by ID.
+   * Attempts to restart a job execution by ID.
    */
   String restartJobExecution(Long executionId) throws Exception;
 

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
@@ -5,8 +5,8 @@ import org.springframework.batch.core.JobExecutionException;
 /**
  * Service interface for managing and running Spring Batch jobs.
  * <p>
- * Provides operations to launch the candidate anonymisation job and to retrieve a plain-text
- * summary of recent job executions.
+ * Provides operations to launch, stop and restart the candidate anonymisation job and to retrieve
+ * a plain-text summary of recent job executions.
  * </p>
  */
 public interface BatchJobService {

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobService.java
@@ -22,4 +22,9 @@ public interface BatchJobService {
    */
   String getJobExecutionsSummary();
 
- }
+  /**
+   * Attempts to stop a running job execution by ID.
+   */
+  String stopJobExecution(Long executionId) throws Exception;
+
+}

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
@@ -91,7 +91,11 @@ public class BatchJobServiceImpl implements BatchJobService {
     LocalDateTime start = exec.getStartTime();
     LocalDateTime end   = exec.getEndTime();
     return String.format(
-        "[%d] %s %s %s - %s%n",
+        "Execution ID: %d%n" +
+            "Job Name    : %s%n" +
+            "Status      : %s%n" +
+            "Start Time  : %s%n" +
+            "End Time    : %s%n%n",
         exec.getId(),
         exec.getJobInstance().getJobName(),
         exec.getStatus(),

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
@@ -1,0 +1,103 @@
+package org.tctalent.anonymization.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implements BatchJobService methods for managing and running batch jobs.
+ * <p>
+ * Provides a method to launch a candidate anonymisation job. Only one job instance runs per day
+ * by including the current date as a unique job parameter.
+ *
+ * @author sadatmalik
+ */
+@Service
+public class BatchJobServiceImpl implements BatchJobService {
+
+  private final JobLauncher asyncJobLauncher;
+  private final Job candidateMigrationJob;
+  private final JobExplorer jobExplorer;
+
+  public BatchJobServiceImpl(
+      @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
+      @Qualifier("candidateMigrationJob") Job candidateMigrationJob,
+      JobExplorer jobExplorer) {
+    this.asyncJobLauncher = asyncJobLauncher;
+    this.candidateMigrationJob = candidateMigrationJob;
+    this.jobExplorer = jobExplorer;
+  }
+
+  /**
+   * Launches the candidate anonymisation batch job. A unique job parameter "jobDate" is added
+   * based on the current date to enforce a single job instance per day.
+   *
+   * @return a String with a success message if the job is launched successfully
+   * @throws JobExecutionException if the job launch fails
+   */
+  @Override
+  public String runCandidateMigrationJob() throws JobExecutionException {
+    try {
+      // Job params must be unique per job execution, if not the job will not run
+      // We enforce a max of one job instance per day by setting a date parameter
+      JobParameters params = new JobParametersBuilder()
+          .addString("jobDate", LocalDate.now().toString()) // e.g., "2025-04-15"
+          .toJobParameters();
+
+      asyncJobLauncher.run(candidateMigrationJob, params);
+      return "Job '" + candidateMigrationJob.getName() + "' launched successfully.";
+
+    } catch (Exception e) {
+      throw new JobExecutionException("Job launch failed: " + e.getMessage());
+    }
+
+  }
+
+  /**
+   * Builds a plain-text summary of up to 20 recent executions per job.
+   * Each line: [executionId] jobName status startTime - endTime
+   */
+  @Override
+  public String getJobExecutionsSummary() {
+    StringBuilder sb = new StringBuilder();
+
+    for (String jobName : jobExplorer.getJobNames()) {
+      // fetch up to 20 recent instances
+      List<JobInstance> instances = jobExplorer.getJobInstances(jobName, 0, 20);
+      for (JobInstance instance : instances) {
+        for (JobExecution exec : jobExplorer.getJobExecutions(instance)) {
+          sb.append(formatExecution(exec));
+        }
+      }
+    }
+
+    return !sb.isEmpty() ? sb.toString() : "No job executions found.";
+  }
+
+  /**
+   * Formats a single JobExecution as: [<executionId>] <jobName> <status> <startTime> - <endTime>
+   */
+  private String formatExecution(JobExecution exec) {
+    LocalDateTime start = exec.getStartTime();
+    LocalDateTime end   = exec.getEndTime();
+    return String.format(
+        "[%d] %s %s %s - %s%n",
+        exec.getId(),
+        exec.getJobInstance().getJobName(),
+        exec.getStatus(),
+        start == null ? "null" : start,
+        end   == null ? "null" : end
+    );
+  }
+
+}

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -28,14 +29,18 @@ public class BatchJobServiceImpl implements BatchJobService {
   private final JobLauncher asyncJobLauncher;
   private final Job candidateMigrationJob;
   private final JobExplorer jobExplorer;
+  private final JobOperator jobOperator;
+
 
   public BatchJobServiceImpl(
       @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
       @Qualifier("candidateMigrationJob") Job candidateMigrationJob,
-      JobExplorer jobExplorer) {
+      JobExplorer jobExplorer,
+      JobOperator jobOperator) {
     this.asyncJobLauncher = asyncJobLauncher;
     this.candidateMigrationJob = candidateMigrationJob;
     this.jobExplorer = jobExplorer;
+    this.jobOperator = jobOperator;
   }
 
   /**
@@ -82,6 +87,14 @@ public class BatchJobServiceImpl implements BatchJobService {
     }
 
     return !sb.isEmpty() ? sb.toString() : "No job executions found.";
+  }
+
+  @Override
+  public String stopJobExecution(Long executionId) throws Exception {
+    boolean stopped = jobOperator.stop(executionId);
+    return stopped
+        ? "Job execution " + executionId + " stop initiated successfully."
+        : "Job execution " + executionId + " could not be stopped (maybe already completed or not running).";
   }
 
   /**

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
@@ -97,6 +97,12 @@ public class BatchJobServiceImpl implements BatchJobService {
         : "Job execution " + executionId + " could not be stopped (maybe already completed or not running).";
   }
 
+  @Override
+  public String restartJobExecution(Long executionId) throws Exception {
+    Long newExecutionId = jobOperator.restart(executionId);
+    return "Job execution " + executionId + " was restarted successfully with new execution ID: " + newExecutionId;
+  }
+
   /**
    * Formats a single JobExecution as: [<executionId>] <jobName> <status> <startTime> - <endTime>
    */

--- a/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
+++ b/src/main/java/org/tctalent/anonymization/service/BatchJobServiceImpl.java
@@ -28,19 +28,18 @@ public class BatchJobServiceImpl implements BatchJobService {
 
   private final JobLauncher asyncJobLauncher;
   private final Job candidateMigrationJob;
-  private final JobExplorer jobExplorer;
   private final JobOperator jobOperator;
-
+  private final JobExplorer jobExplorer;
 
   public BatchJobServiceImpl(
       @Qualifier("asyncJobLauncher") JobLauncher asyncJobLauncher,
       @Qualifier("candidateMigrationJob") Job candidateMigrationJob,
-      JobExplorer jobExplorer,
-      JobOperator jobOperator) {
+      @Qualifier("asyncJobOperator") JobOperator jobOperator,
+      JobExplorer jobExplorer) {
     this.asyncJobLauncher = asyncJobLauncher;
     this.candidateMigrationJob = candidateMigrationJob;
-    this.jobExplorer = jobExplorer;
     this.jobOperator = jobOperator;
+    this.jobExplorer = jobExplorer;
   }
 
   /**

--- a/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
@@ -1,0 +1,122 @@
+package org.tctalent.anonymization.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class BatchJobServiceImplTest {
+
+  @Mock private JobLauncher asyncJobLauncher;
+  @Mock private Job candidateMigrationJob;
+  @Mock private JobExplorer jobExplorer;
+
+  @InjectMocks private BatchJobServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    when(candidateMigrationJob.getName()).thenReturn("candidateMigrationJob");
+  }
+
+  @Test
+  @DisplayName("Run candidate migration job")
+  void runCandidateMigrationJob_success() throws Exception {
+    // When
+    String result = service.runCandidateMigrationJob();
+
+    // Then
+    assertEquals("Job 'candidateMigrationJob' launched successfully.", result);
+
+    // And verify that we passed a 'jobDate' param equal to today
+    ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+    verify(asyncJobLauncher).run(eq(candidateMigrationJob), captor.capture());
+
+    JobParameters params = captor.getValue();
+    assertTrue(params.getParameters().containsKey("jobDate"));
+    String dateParam = params.getString("jobDate");
+    assertEquals(LocalDate.now().toString(), dateParam);
+  }
+
+  @Test
+  @DisplayName("Run candidate migration job fails")
+  void runCandidateMigrationJob_failure() throws Exception {
+    // Given
+    when(asyncJobLauncher
+        .run(eq(candidateMigrationJob), any(JobParameters.class)))
+        .thenThrow(new RuntimeException("boom!"));
+
+    // When / Then
+    JobExecutionException ex =
+        assertThrows(JobExecutionException.class, () -> service.runCandidateMigrationJob());
+    assertTrue(ex.getMessage().contains("Job launch failed: boom!"));
+  }
+
+  @Test
+  @DisplayName("Get job execution summary")
+  void getJobExecutionsSummary_withExecutions() {
+    // Given
+    when(jobExplorer.getJobNames()).thenReturn(List.of("jobA"));
+    JobInstance instance = new JobInstance(10L, "jobA");
+    when(jobExplorer.getJobInstances("jobA", 0, 20))
+        .thenReturn(List.of(instance));
+
+    JobExecution exec = new JobExecution(instance, null);
+    exec.setId(100L);
+    exec.setStatus(BatchStatus.COMPLETED);
+    LocalDateTime start = LocalDateTime.of(2025, 4, 16, 12, 0);
+    LocalDateTime end   = LocalDateTime.of(2025, 4, 16, 12, 30);
+    exec.setStartTime(start);
+    exec.setEndTime(end);
+
+    when(jobExplorer.getJobExecutions(instance))
+        .thenReturn(List.of(exec));
+
+    // When
+    String summary = service.getJobExecutionsSummary();
+
+    // Then
+    String expectedLine = String.format(
+        "[%d] %s %s %s - %s",
+        100L, "jobA", "COMPLETED", start.toString(), end.toString()
+    );
+    assertTrue(summary.contains(expectedLine));
+    assertTrue(summary.endsWith("\n")); // Check each line ends with a newline
+  }
+
+  @Test
+  @DisplayName("Get job execution summary empty")
+  void getJobExecutionsSummary_empty() {
+    // Given no job names
+    when(jobExplorer.getJobNames()).thenReturn(Collections.emptyList());
+
+    // When
+    String summary = service.getJobExecutionsSummary();
+
+    // Then
+    assertEquals("No job executions found.", summary);
+  }
+
+}

--- a/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
@@ -101,8 +101,12 @@ class BatchJobServiceImplTest {
 
     // Then
     String expectedLine = String.format(
-        "[%d] %s %s %s - %s",
-        100L, "jobA", "COMPLETED", start.toString(), end.toString()
+        "Execution ID: %d%n" +
+            "Job Name    : %s%n" +
+            "Status      : %s%n" +
+            "Start Time  : %s%n" +
+            "End Time    : %s%n%n",
+        100L, "jobA", "COMPLETED", start, end
     );
     assertTrue(summary.contains(expectedLine));
     assertTrue(summary.endsWith("\n")); // Check each line ends with a newline
@@ -114,19 +118,20 @@ class BatchJobServiceImplTest {
     // Given no job names
     when(jobExplorer.getJobNames()).thenReturn(Collections.emptyList());
 
-    // When
+    // When / Then
     String summary = service.getJobExecutionsSummary();
 
-    // Then
     assertEquals("No job executions found.", summary);
   }
 
   @Test
   @DisplayName("Get job execution summary with no executions")
   void stopJobExecution_shouldReturnSuccessMessage_whenStopped() throws Exception {
+    // Given
     long executionId = 1L;
     when(jobOperator.stop(executionId)).thenReturn(true);
 
+    // When / Then
     String result = service.stopJobExecution(executionId);
 
     assertEquals("Job execution 1 stop initiated successfully.", result);
@@ -135,9 +140,11 @@ class BatchJobServiceImplTest {
   @Test
   @DisplayName("Get job execution summary with no executions")
   void stopJobExecution_shouldReturnFailureMessage_whenNotStopped() throws Exception {
+    // Given
     long executionId = 2L;
     when(jobOperator.stop(executionId)).thenReturn(false);
 
+    // When / Then
     String result = service.stopJobExecution(executionId);
 
     assertEquals("Job execution 2 could not be stopped (maybe already completed or not running).", result);
@@ -146,11 +153,13 @@ class BatchJobServiceImplTest {
   @Test
   @DisplayName("Restart job execution should return success message with new execution ID")
   void restartJobExecution_shouldReturnSuccessMessage_withNewExecutionId() throws Exception {
+    // Given
     long oldExecutionId = 3L;
     long newExecutionId = 100L;
 
     when(jobOperator.restart(oldExecutionId)).thenReturn(newExecutionId);
 
+    // When / Then
     String result = service.restartJobExecution(oldExecutionId);
 
     assertEquals("Job execution 3 was restarted successfully with new execution ID: 100", result);

--- a/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
+++ b/src/test/java/org/tctalent/anonymization/service/BatchJobServiceImplTest.java
@@ -25,6 +25,7 @@ import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -33,6 +34,7 @@ class BatchJobServiceImplTest {
   @Mock private JobLauncher asyncJobLauncher;
   @Mock private Job candidateMigrationJob;
   @Mock private JobExplorer jobExplorer;
+  @Mock private JobOperator jobOperator;
 
   @InjectMocks private BatchJobServiceImpl service;
 
@@ -117,6 +119,41 @@ class BatchJobServiceImplTest {
 
     // Then
     assertEquals("No job executions found.", summary);
+  }
+
+  @Test
+  @DisplayName("Get job execution summary with no executions")
+  void stopJobExecution_shouldReturnSuccessMessage_whenStopped() throws Exception {
+    long executionId = 1L;
+    when(jobOperator.stop(executionId)).thenReturn(true);
+
+    String result = service.stopJobExecution(executionId);
+
+    assertEquals("Job execution 1 stop initiated successfully.", result);
+  }
+
+  @Test
+  @DisplayName("Get job execution summary with no executions")
+  void stopJobExecution_shouldReturnFailureMessage_whenNotStopped() throws Exception {
+    long executionId = 2L;
+    when(jobOperator.stop(executionId)).thenReturn(false);
+
+    String result = service.stopJobExecution(executionId);
+
+    assertEquals("Job execution 2 could not be stopped (maybe already completed or not running).", result);
+  }
+
+  @Test
+  @DisplayName("Restart job execution should return success message with new execution ID")
+  void restartJobExecution_shouldReturnSuccessMessage_withNewExecutionId() throws Exception {
+    long oldExecutionId = 3L;
+    long newExecutionId = 100L;
+
+    when(jobOperator.restart(oldExecutionId)).thenReturn(newExecutionId);
+
+    String result = service.restartJobExecution(oldExecutionId);
+
+    assertEquals("Job execution 3 was restarted successfully with new execution ID: 100", result);
   }
 
 }


### PR DESCRIPTION
This PR:

- implements migration job management endpoints
- adds support for browsing, stopping and restarting api migrations 

