### PR TITLE
102 remove batch job run on startup from service property

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -131,11 +131,6 @@ module "ecs_service" {
           name  = "TC_PASSWORD"
           value = ""
         },
-        {
-          name  = "SPRING_BATCH_JOB_ENABLED"
-          value = var.run_anonymisation_on_startup
-        },
-
       ]
 
       # Example image used requires access to write to root filesystem

--- a/infra/terraform/tc-api-prod/main.tf
+++ b/infra/terraform/tc-api-prod/main.tf
@@ -18,7 +18,6 @@ module tc-prod {
   tc_api_url = "https://tctalent.org/api/admin"
   tc_api_search_id = 3434
   tc_api_username = "tc-api"
-  run_anonymisation_on_startup = false
   acm_certificate_arn = "arn:aws:acm:us-east-1:968457613372:certificate/5dd8d298-5460-4396-ad5e-24e3a2dfa774"
 }
 

--- a/infra/terraform/tc-api-test/main.tf
+++ b/infra/terraform/tc-api-test/main.tf
@@ -18,7 +18,6 @@ module tc-test {
   tc_api_url = "https://tctalent-test.org/api/admin"
   tc_api_search_id = 2682
   tc_api_username = "tc-api"
-  run_anonymisation_on_startup = false
   acm_certificate_arn = "arn:aws:acm:us-east-1:231168606641:certificate/3a502945-f505-46f9-aa08-523c2be2593d"
 }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -83,10 +83,6 @@ variable "tc_api_username" {
   description = "Talent Catalog username used by tc-api"
 }
 
-variable "run_anonymisation_on_startup" {
-  description = "If true run the DB anonymisation on startup"
-}
-
 variable "acm_certificate_arn" {
   description = "The ARN of an ACM certificate"
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,8 +58,6 @@ spring:
   batch:
     jdbc:
       initialize-schema: never # batch schema are initialised by flyway
-    job:
-      enabled: ${SPRING_BATCH_JOB_ENABLED:false} # enable/disable auto-run of jobs
 
 # Actuator
 management:


### PR DESCRIPTION
This PR -

- Removes the batch job enabled property from the api service configuration (api migrations are now managed through the batch controller endpoints)

- Removes the corresponding AWS task definition property from the terraform configuration